### PR TITLE
Fix undo trap

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -13,8 +13,7 @@ import {
 	RichText,
 	AlignmentControl,
 } from '@wordpress/block-editor';
-import { compose } from '@wordpress/compose';
-import {useDispatch, withSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -46,7 +45,6 @@ function ShareOnTwitterBlock( {
 	setAttributes,
 	onReplace,
 	attributes,
-	postLink,
 } ) {
 	const {
 		content,
@@ -58,7 +56,13 @@ function ShareOnTwitterBlock( {
 		permalink,
 	} = attributes;
 
-	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( 'core/block-editor' );
+	const postLink = useSelect( ( select ) => {
+		return select( 'core/editor' ).getPermalink();
+	}, [] );
+
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
+		'core/block-editor'
+	);
 
 	useEffect( () => {
 		if ( permalink === undefined ) {
@@ -179,12 +183,4 @@ function ShareOnTwitterBlock( {
 	);
 }
 
-const applyWithSelect = withSelect( ( select ) => {
-	const { getPermalink } = select( 'core/editor' );
-
-	return {
-		postLink: getPermalink(),
-	};
-} );
-
-export default compose( [ applyWithSelect ] )( ShareOnTwitterBlock );
+export default ShareOnTwitterBlock;

--- a/src/edit.js
+++ b/src/edit.js
@@ -14,7 +14,7 @@ import {
 	AlignmentControl,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import {useDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -58,8 +58,12 @@ function ShareOnTwitterBlock( {
 		permalink,
 	} = attributes;
 
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( 'core/block-editor' );
+
 	useEffect( () => {
 		if ( permalink === undefined ) {
+			// This effect should not create an undo level.
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { permalink: postLink } );
 		}
 	}, [ permalink ] );


### PR DESCRIPTION
## What
PR fixes "undo trap" - An issue when the user sees that the Undo action is active, but clicking on it does nothing.

## Why
The edit component uses the effect to set the `permalink` attribute; it creates an undo level. Clicking the "Undo" button will reset the attribute and the effect to run again. This loop creates an "undo trap."

## How
Calling `__unstableMarkNextChangeAsNotPersistent` before `setAttributes` will tell the WP not to persist changes and create undo level.

P.S. I also refactored code to use hooks instead of the `withSelect`.

**Before**

https://user-images.githubusercontent.com/240569/160246754-1a7293e7-1a6a-4342-ba17-5db198937f6a.mp4

**After**

https://user-images.githubusercontent.com/240569/160246771-58ed26ae-8539-4ede-af43-718246be4b1b.mp4


